### PR TITLE
DOC: fix docstring typo in rank_compare_2indep

### DIFF
--- a/statsmodels/stats/nonparametric.py
+++ b/statsmodels/stats/nonparametric.py
@@ -374,7 +374,7 @@ def rank_compare_2indep(x1, x2, use_t=True):
     ----------
     x1, x2 : array_like
         Array of samples, should be one-dimensional.
-    use_t : poolean
+    use_t : boolean
         If use_t is true, the t distribution with Welch-Satterthwaite type
         degrees of freedom is used for p-value and confidence interval.
         If use_t is false, then the normal distribution is used.


### PR DESCRIPTION
Type is "poolean" but probably should be "boolean".

- [x] closes #xxxx (N/A)
- [x] tests added / passed (N/A). 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

